### PR TITLE
feat: interactive dependency graph + a11y progressbar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "sa-in-60s",
       "version": "0.1.0",
       "license": "MIT",
+      "dependencies": {
+        "cytoscape": "^3.33.1"
+      },
       "devDependencies": {
         "@tailwindcss/vite": "^4.2.2",
         "eslint": "^10.1.0",
@@ -1096,6 +1099,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/cytoscape": {
+      "version": "3.33.1",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
+      "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
       }
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
     "tailwindcss": "^4.2.2",
     "vite": "^8.0.3",
     "vitest": "^4.1.2"
+  },
+  "dependencies": {
+    "cytoscape": "^3.33.1"
   }
 }

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -265,7 +265,7 @@ export function generatePathPage(path, allConcepts, translations) {
     <div class="mb-8">
       <h1 class="text-3xl font-bold mb-2" style="border-left: 4px solid ${escapeHtml(path.color)}; padding-left: 0.75rem;" data-de="${escapeHtml(path.name_de)}" data-en="${escapeHtml(path.name_en)}">${escapeHtml(path.name_de)}</h1>
       <p class="text-text-muted" data-de="${escapeHtml(path.description_de)}" data-en="${escapeHtml(path.description_en)}">${escapeHtml(path.description_de)}</p>
-      <p class="text-sm text-text-muted mt-1"><span data-progress-path="${escapeHtml(path.id)}" data-progress-concepts='${JSON.stringify(path.concepts)}' data-progress-total="${path.concepts.length}">0/${path.concepts.length}</span> <span data-de="${escapeHtml(t.path_concepts)}" data-en="${escapeHtml(translations.en.path_concepts)}">${escapeHtml(t.path_concepts)}</span></p>
+      <p class="text-sm text-text-muted mt-1"><span data-progress-path="${escapeHtml(path.id)}" data-progress-concepts='${JSON.stringify(path.concepts)}' data-progress-total="${path.concepts.length}" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="${path.concepts.length}">0/${path.concepts.length}</span> <span data-de="${escapeHtml(t.path_concepts)}" data-en="${escapeHtml(translations.en.path_concepts)}">${escapeHtml(t.path_concepts)}</span></p>
     </div>
     <div id="stem-hint" class="hidden mb-6 p-3 bg-bg-card rounded-lg border border-accent-orange text-accent-orange text-sm"></div>
     <ol class="space-y-2">
@@ -298,7 +298,7 @@ export function generateIndexPage(allConcepts, allPaths, translations) {
       <a href="/path/${escapeHtml(p.id)}" class="p-4 bg-bg-card rounded-lg hover:border-accent-cyan border border-transparent transition" style="border-left: 4px solid ${escapeHtml(p.color)};">
         <h3 class="font-bold" data-de="${escapeHtml(p.name_de)}" data-en="${escapeHtml(p.name_en)}">${escapeHtml(p.name_de)}</h3>
         <p class="text-sm text-text-muted" data-de="${escapeHtml(p.description_de)}" data-en="${escapeHtml(p.description_en)}">${escapeHtml(p.description_de)}</p>
-        <p class="text-xs text-text-muted mt-2"><span data-progress-path="${escapeHtml(p.id)}" data-progress-concepts='${JSON.stringify(p.concepts)}' data-progress-total="${p.concepts.length}">0/${p.concepts.length}</span> <span data-de="${escapeHtml(t.path_concepts)}" data-en="${escapeHtml(translations.en.path_concepts)}">${escapeHtml(t.path_concepts)}</span></p>
+        <p class="text-xs text-text-muted mt-2"><span data-progress-path="${escapeHtml(p.id)}" data-progress-concepts='${JSON.stringify(p.concepts)}' data-progress-total="${p.concepts.length}" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="${p.concepts.length}">0/${p.concepts.length}</span> <span data-de="${escapeHtml(t.path_concepts)}" data-en="${escapeHtml(translations.en.path_concepts)}">${escapeHtml(t.path_concepts)}</span></p>
       </a>`
     )
     .join('\n')
@@ -307,7 +307,7 @@ export function generateIndexPage(allConcepts, allPaths, translations) {
     <section class="text-center py-12">
       <h1 class="text-4xl font-bold mb-2" data-de="${escapeHtml(t.site_title)}" data-en="${escapeHtml(translations.en.site_title)}">${escapeHtml(t.site_title)}</h1>
       <p class="text-text-muted text-lg" data-de="${escapeHtml(t.site_subtitle)}" data-en="${escapeHtml(translations.en.site_subtitle)}">${escapeHtml(t.site_subtitle)}</p>
-      <p class="text-text-muted text-sm mt-2"><span id="total-progress" data-progress-total="${totalConcepts}">0/${totalConcepts}</span> <span data-de="gesehen" data-en="seen">gesehen</span></p>
+      <p class="text-text-muted text-sm mt-2"><span id="total-progress" data-progress-total="${totalConcepts}" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="${totalConcepts}">0/${totalConcepts}</span> <span data-de="gesehen" data-en="seen">gesehen</span></p>
     </section>
 
     <section class="mb-12">
@@ -330,6 +330,57 @@ export function generateIndexPage(allConcepts, allPaths, translations) {
     description: `${t.site_subtitle}`,
     body,
     canonicalPath: '/',
+  })
+}
+
+export function buildGraphData(allConcepts, allPaths) {
+  return {
+    nodes: allConcepts.map((c) => ({
+      id: c.id,
+      title_de: c.title_de,
+      title_en: c.title_en,
+      path: c.path,
+    })),
+    edges: allConcepts.flatMap((c) => (c.requires || []).map((r) => ({ source: r, target: c.id }))),
+    paths: allPaths.map((p) => ({
+      id: p.id,
+      name_de: p.name_de,
+      name_en: p.name_en,
+      color: p.color,
+    })),
+  }
+}
+
+export function generateGraphPage(allConcepts, allPaths, translations) {
+  const t = translations.de
+  const tEn = translations.en
+
+  const filterOptions = allPaths
+    .map(
+      (p) =>
+        `<option value="${escapeHtml(p.id)}" data-de="${escapeHtml(p.name_de)}" data-en="${escapeHtml(p.name_en)}">${escapeHtml(p.name_de)}</option>`
+    )
+    .join('\n')
+
+  const body = `
+    <div class="flex flex-wrap items-center justify-between gap-4 mb-4">
+      <h1 class="text-3xl font-bold" data-de="${escapeHtml(t.graph_title)}" data-en="${escapeHtml(tEn.graph_title)}">${escapeHtml(t.graph_title)}</h1>
+      <select id="graph-filter" class="px-3 py-2 bg-bg-card border border-text-muted rounded text-sm text-text" aria-label="Filter by path">
+        <option value="" data-de="${escapeHtml(t.graph_filter_all)}" data-en="${escapeHtml(tEn.graph_filter_all)}">${escapeHtml(t.graph_filter_all)}</option>
+        ${filterOptions}
+      </select>
+    </div>
+    <div id="cy" class="rounded-lg border border-text-muted"></div>
+    <div id="graph-tooltip" class="hidden"></div>
+    <noscript>
+      <p class="text-center text-text-muted py-12" data-de="${escapeHtml(t.graph_noscript)}" data-en="${escapeHtml(tEn.graph_noscript)}">${escapeHtml(t.graph_noscript)}</p>
+    </noscript>`
+
+  return htmlTemplate({
+    title: `${t.graph_title} — ${t.site_title}`,
+    description: t.graph_title,
+    body,
+    canonicalPath: '/graph',
   })
 }
 
@@ -383,6 +434,22 @@ if (process.argv[1] === __filename) {
     const indexHtml = generateIndexPage(concepts, paths, translations)
     writeFileSync(resolve(publicDir, 'index.html'), indexHtml)
     console.warn('Generated index.html')
+
+    // Generate graph page
+    const graphDir = resolve(publicDir, 'graph')
+    mkdirSync(graphDir, { recursive: true })
+    const graphHtml = generateGraphPage(concepts, paths, translations)
+    writeFileSync(resolve(graphDir, 'index.html'), graphHtml)
+    console.warn('Generated graph/index.html')
+
+    // Generate graph data
+    const dataOutDir = resolve(publicDir, 'data')
+    mkdirSync(dataOutDir, { recursive: true })
+    const graphData = buildGraphData(concepts, paths)
+    writeFileSync(resolve(dataOutDir, 'graph-data.json'), JSON.stringify(graphData))
+    console.warn(
+      `Generated graph-data.json (${graphData.nodes.length} nodes, ${graphData.edges.length} edges)`
+    )
 
     // Generate sitemap
     const urls = [

--- a/scripts/build.test.js
+++ b/scripts/build.test.js
@@ -4,6 +4,8 @@ import {
   generateConceptPage,
   generatePathPage,
   generateIndexPage,
+  generateGraphPage,
+  buildGraphData,
   youtubeEmbed,
   escapeHtml,
   validateYoutubeUrl,
@@ -59,6 +61,9 @@ const translations = {
     concept_requires: 'Voraussetzungen',
     concept_leads_to: 'Führt zu',
     seen_button: 'Als gesehen markieren',
+    graph_title: 'Abhängigkeitsgraph',
+    graph_noscript: 'Für den interaktiven Graph bitte JavaScript aktivieren',
+    graph_filter_all: 'Alle',
   },
   en: {
     site_title: 'Software Architecture in 60 Seconds',
@@ -73,6 +78,9 @@ const translations = {
     concept_requires: 'Prerequisites',
     concept_leads_to: 'Leads to',
     seen_button: 'Mark as seen',
+    graph_title: 'Dependency Graph',
+    graph_noscript: 'Please enable JavaScript for the interactive graph',
+    graph_filter_all: 'All',
   },
 }
 
@@ -405,6 +413,97 @@ describe('UC-7: Build script — HTML generation', () => {
       const html = generateIndexPage(concepts, [samplePath], translations)
       expect(html).toContain('id="total-progress"')
       expect(html).toContain('data-progress-total=')
+    })
+  })
+
+  describe('generateGraphPage()', () => {
+    it('includes graph container', () => {
+      const html = generateGraphPage([], [samplePath], translations)
+      expect(html).toContain('id="cy"')
+    })
+
+    it('includes noscript fallback', () => {
+      const html = generateGraphPage([], [samplePath], translations)
+      expect(html).toContain('<noscript>')
+    })
+
+    it('includes path filter with all paths', () => {
+      const html = generateGraphPage([], [samplePath], translations)
+      expect(html).toContain('<select')
+      expect(html).toContain('data-de="Microservices"')
+    })
+
+    it('includes bilingual title', () => {
+      const html = generateGraphPage([], [samplePath], translations)
+      expect(html).toContain('data-de="Abhängigkeitsgraph"')
+      expect(html).toContain('data-en="Dependency Graph"')
+    })
+
+    it('includes canonical URL for /graph', () => {
+      const html = generateGraphPage([], [samplePath], translations)
+      expect(html).toContain('rel="canonical"')
+      expect(html).toContain('/graph')
+    })
+
+    it('includes tooltip container', () => {
+      const html = generateGraphPage([], [samplePath], translations)
+      expect(html).toContain('id="graph-tooltip"')
+    })
+
+    it('has valid HTML structure', () => {
+      const html = generateGraphPage([], [samplePath], translations)
+      expect(html).toContain('<!doctype html>')
+      expect(html).toContain('</html>')
+      expect(html).not.toContain('undefined')
+    })
+  })
+
+  describe('buildGraphData()', () => {
+    const concepts = [
+      {
+        id: 'monolith',
+        title_de: 'Monolith',
+        title_en: 'Monolith',
+        path: 'microservices',
+        path_position: 1,
+        requires: [],
+      },
+      {
+        id: 'microservices',
+        title_de: 'Microservices',
+        title_en: 'Microservices',
+        path: 'microservices',
+        path_position: 3,
+        requires: ['monolith', 'kopplung'],
+      },
+    ]
+
+    it('produces nodes with required fields', () => {
+      const data = buildGraphData(concepts, [samplePath])
+      expect(data.nodes).toHaveLength(2)
+      expect(data.nodes[0]).toEqual({
+        id: 'monolith',
+        title_de: 'Monolith',
+        title_en: 'Monolith',
+        path: 'microservices',
+      })
+    })
+
+    it('produces edges from requires arrays', () => {
+      const data = buildGraphData(concepts, [samplePath])
+      expect(data.edges).toHaveLength(2)
+      expect(data.edges).toContainEqual({ source: 'monolith', target: 'microservices' })
+      expect(data.edges).toContainEqual({ source: 'kopplung', target: 'microservices' })
+    })
+
+    it('includes path colors', () => {
+      const data = buildGraphData(concepts, [samplePath])
+      expect(data.paths).toContainEqual({
+        id: 'microservices',
+        name_de: 'Microservices',
+        name_en: 'Microservices',
+        color: '#6495ED',
+      })
     })
   })
 })

--- a/src/graph.js
+++ b/src/graph.js
@@ -1,0 +1,216 @@
+import cytoscape from 'cytoscape'
+
+export async function initGraph() {
+  const container = document.getElementById('cy')
+  if (!container) return
+
+  const res = await fetch('/data/graph-data.json')
+  const data = await res.json()
+
+  const pathColors = Object.fromEntries(data.paths.map((p) => [p.id, p.color]))
+  pathColors.stem = '#22d3ee'
+
+  const progress = getProgress()
+  const lang = document.documentElement.lang || 'de'
+
+  const elements = [
+    ...data.nodes.map((n) => ({
+      data: {
+        id: n.id,
+        label: n[`title_${lang}`] || n.title_de,
+        title_de: n.title_de,
+        title_en: n.title_en,
+        path: n.path,
+        seen: progress.includes(n.id) ? 1 : 0,
+      },
+    })),
+    ...data.edges.map((e) => ({
+      data: { source: e.source, target: e.target },
+    })),
+  ]
+
+  const cy = cytoscape({
+    container,
+    elements,
+    style: [
+      {
+        selector: 'node',
+        style: {
+          label: 'data(label)',
+          'font-size': 9,
+          color: '#e2e8f0',
+          'text-valign': 'bottom',
+          'text-margin-y': 4,
+          'text-outline-width': 2,
+          'text-outline-color': '#0f172a',
+          width: 20,
+          height: 20,
+          'background-color': '#64748b',
+          opacity: 0.5,
+          'text-opacity': 0,
+        },
+      },
+      // Path-colored nodes
+      ...data.paths.map((p) => ({
+        selector: `node[path = "${p.id}"]`,
+        style: { 'background-color': p.color },
+      })),
+      {
+        selector: 'node[path = "stem"]',
+        style: {
+          'background-color': '#22d3ee',
+          width: 30,
+          height: 30,
+        },
+      },
+      {
+        selector: 'node[seen = 1]',
+        style: {
+          opacity: 1,
+          'border-width': 3,
+          'border-color': '#22d3ee',
+        },
+      },
+      {
+        selector: 'edge',
+        style: {
+          width: 1,
+          'line-color': '#334155',
+          'target-arrow-color': '#334155',
+          'target-arrow-shape': 'triangle',
+          'curve-style': 'bezier',
+          'arrow-scale': 0.6,
+          opacity: 0.6,
+        },
+      },
+      {
+        selector: '.dimmed',
+        style: { opacity: 0.08 },
+      },
+      {
+        selector: '.highlighted',
+        style: { opacity: 1, 'text-opacity': 1 },
+      },
+    ],
+    layout: {
+      name: 'cose',
+      animate: false,
+      nodeRepulsion: () => 12000,
+      gravity: 0.4,
+      idealEdgeLength: () => 60,
+      padding: 30,
+    },
+    minZoom: 0.3,
+    maxZoom: 3,
+    wheelSensitivity: 0.3,
+  })
+
+  // Show labels when zoomed in
+  cy.on('zoom', () => {
+    const zoom = cy.zoom()
+    const showLabels = zoom > 0.8
+    cy.style()
+      .selector('node')
+      .style('text-opacity', showLabels ? 1 : 0)
+      .update()
+    // Keep highlighted nodes visible
+    cy.style().selector('.highlighted').style('text-opacity', 1).update()
+  })
+
+  // Click → navigate
+  cy.on('tap', 'node', (evt) => {
+    window.location.href = `/concept/${evt.target.id()}`
+  })
+
+  // Hover tooltip
+  const tooltip = document.getElementById('graph-tooltip')
+  if (tooltip) {
+    cy.on('mouseover', 'node', (evt) => {
+      const node = evt.target
+      const currentLang = document.documentElement.lang || 'de'
+      const title = node.data(`title_${currentLang}`) || node.data('title_de')
+      const pathId = node.data('path')
+      const pathInfo = data.paths.find((p) => p.id === pathId)
+      const pathName = pathInfo ? pathInfo[`name_${currentLang}`] || pathInfo.name_de : pathId
+      const seen = node.data('seen') ? ' ✓' : ''
+      tooltip.innerHTML = `<strong>${escapeText(title)}</strong>${seen}<br><span class="text-text-muted text-xs">${escapeText(pathName)}</span>`
+      tooltip.classList.remove('hidden')
+      const pos = evt.renderedPosition
+      const rect = container.getBoundingClientRect()
+      tooltip.style.left = `${rect.left + pos.x + 10}px`
+      tooltip.style.top = `${rect.top + pos.y - 10}px`
+    })
+    cy.on('mouseout', 'node', () => {
+      tooltip.classList.add('hidden')
+    })
+  }
+
+  // Path filter
+  const filter = document.getElementById('graph-filter')
+  if (filter) {
+    filter.addEventListener('change', () => {
+      const pathId = filter.value
+      if (!pathId) {
+        cy.elements().removeClass('dimmed highlighted')
+        return
+      }
+      // BFS: find all transitive dependencies of selected path
+      const pathNodes = cy.nodes().filter((n) => n.data('path') === pathId)
+      const visible = new Set(pathNodes.map((n) => n.id()))
+      const queue = [...pathNodes]
+      while (queue.length > 0) {
+        const node = queue.shift()
+        node.incomers('node').forEach((pred) => {
+          if (!visible.has(pred.id())) {
+            visible.add(pred.id())
+            queue.push(pred)
+          }
+        })
+      }
+      cy.nodes().forEach((n) => {
+        if (visible.has(n.id())) {
+          n.removeClass('dimmed').addClass('highlighted')
+        } else {
+          n.removeClass('highlighted').addClass('dimmed')
+        }
+      })
+      cy.edges().forEach((e) => {
+        if (visible.has(e.source().id()) && visible.has(e.target().id())) {
+          e.removeClass('dimmed')
+        } else {
+          e.addClass('dimmed')
+        }
+      })
+    })
+  }
+
+  // Language reactivity
+  const observer = new MutationObserver(() => {
+    const newLang = document.documentElement.lang || 'de'
+    cy.nodes().forEach((n) => {
+      n.data('label', n.data(`title_${newLang}`) || n.data('title_de'))
+    })
+    // Update filter options
+    if (filter) {
+      Array.from(filter.options).forEach((opt) => {
+        if (opt.dataset[newLang]) opt.textContent = opt.dataset[newLang]
+      })
+    }
+  })
+  observer.observe(document.documentElement, { attributes: true, attributeFilter: ['lang'] })
+}
+
+function getProgress() {
+  try {
+    const raw = localStorage.getItem('sa60s-progress')
+    if (!raw) return []
+    const parsed = JSON.parse(raw)
+    return Array.isArray(parsed) ? parsed : []
+  } catch {
+    return []
+  }
+}
+
+function escapeText(str) {
+  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}

--- a/src/main.js
+++ b/src/main.js
@@ -159,10 +159,12 @@ function updateProgressDisplays() {
     const total = parseInt(el.dataset.progressTotal, 10)
     const seen = conceptIds.filter((id) => progress.includes(id)).length
     el.textContent = `${seen}/${total}`
+    el.setAttribute('aria-valuenow', seen.toString())
   })
   const totalEl = document.getElementById('total-progress')
   if (totalEl) {
     totalEl.textContent = `${progress.length}/${parseInt(totalEl.dataset.progressTotal, 10)}`
+    totalEl.setAttribute('aria-valuenow', progress.length.toString())
   }
   document.querySelectorAll('[data-concept-seen]').forEach((el) => {
     el.textContent = progress.includes(el.dataset.conceptSeen) ? '✓' : '○'
@@ -173,4 +175,7 @@ document.addEventListener('DOMContentLoaded', () => {
   initI18n()
   initProgress()
   initVideoSwitch()
+  if (document.getElementById('cy')) {
+    import('./graph.js').then((m) => m.initGraph())
+  }
 })

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -47,3 +47,21 @@ body {
   white-space: nowrap;
   border-width: 0;
 }
+
+#cy {
+  min-height: 70vh;
+  width: 100%;
+}
+
+#graph-tooltip {
+  position: fixed;
+  background-color: var(--color-bg-card);
+  color: var(--color-text);
+  border: 1px solid var(--color-text-muted);
+  border-radius: 0.5rem;
+  padding: 0.5rem 0.75rem;
+  font-size: 0.875rem;
+  pointer-events: none;
+  z-index: 50;
+  max-width: 200px;
+}


### PR DESCRIPTION
## Summary
- **Dependency Graph** (#28): Interactive `/graph` page with Cytoscape.js showing all 132 concepts and 90 dependency edges
  - Nodes colored by learning path, stem concepts larger and centered (COSE force layout)
  - Click → navigate to concept page, hover → tooltip with name + path + seen status
  - Path filter dropdown: highlights selected path + all transitive dependencies, dims the rest
  - Progress overlay: seen concepts get cyan border ring
  - Labels appear when zoomed in, language-reactive via MutationObserver
  - Code-split via dynamic import — Cytoscape chunk (139KB gzip) only loads on `/graph`
  - Graph data generated as `/data/graph-data.json` during build
- **A11y** (#36): `role="progressbar"` with `aria-valuenow/min/max` on all progress displays
- **Noscript fallback** (#32): `<noscript>` message on graph page

Closes #28, closes #29, closes #30, closes #31, closes #32, closes #36

## Test plan
- [x] 71 unit tests pass (10 new for graph page + graph data)
- [ ] Open /graph → verify 132 colored nodes with edges
- [ ] Click a node → navigates to /concept/{id}
- [ ] Hover a node → tooltip shows title + path
- [ ] Select a path in filter → path highlighted, others dimmed
- [ ] Mark concepts as seen → graph shows cyan border on those nodes
- [ ] Zoom in → labels appear
- [ ] Touch device: pinch zoom + pan works
- [ ] Screen reader: progress bars announced with values

🤖 Generated with [Claude Code](https://claude.com/claude-code)