### PR TITLE
QR-Weiterleitung auf die Konzeptseite statt direkt zu YouTube

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1059,9 +1059,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -567,24 +567,22 @@ export function generateGraphPage(
   })
 }
 
+// Der QR-Code im Buch fuehrt hierher. Frueher sprang diese Seite per JavaScript
+// direkt zu YouTube. Das hatte zwei Nachteile: der Besucher verliess die Seite,
+// bevor GoatCounter zaehlen konnte, und das Video lief ausserhalb des eigenen
+// Kontexts. Jetzt geht es auf die Konzeptseite, die das Video ohnehin einbettet,
+// den zugehoerigen Text zeigt und das GoatCounter-Snippet traegt.
+// Statischer Meta-Refresh statt JavaScript, damit es auch ohne JS funktioniert.
 export function generateGoRedirect(concept) {
-  const deUrl = concept.youtube_de || ''
-  const enUrl = concept.youtube_en || deUrl
-  const fallback = `${BASE_URL}/concept/${concept.id}`
+  const target = `${BASE_URL}/concept/${concept.id}`
   return `<!doctype html>
-<html><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<html lang="de"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<meta http-equiv="refresh" content="0; url=${escapeHtml(target)}">
+<link rel="canonical" href="${escapeHtml(target)}">
 <title>${escapeHtml(concept.title_de)} — Video</title>
 <style>body{font-family:sans-serif;background:#0f172a;color:#e2e8f0;display:flex;align-items:center;justify-content:center;min-height:100vh;margin:0;text-align:center}</style>
-<script>
-(function(){
-  var lang=(localStorage.getItem('sa60s-lang')||(navigator.language||'').slice(0,2)==='de'?'de':'en');
-  var de=${JSON.stringify(deUrl)};
-  var en=${JSON.stringify(enUrl)};
-  var url=(lang==='de'?de:en)||de||en;
-  if(url)window.location.replace(url);
-})();
-</script></head>
-<body><p><a href="${escapeHtml(fallback)}" style="color:#22d3ee">${escapeHtml(concept.title_de)} — Video</a></p></body></html>`
+</head>
+<body><p><a href="${escapeHtml(target)}" style="color:#22d3ee">${escapeHtml(concept.title_de)} — Video ansehen</a></p></body></html>`
 }
 
 export function generateAiRedirect(concept) {

--- a/scripts/build.test.js
+++ b/scripts/build.test.js
@@ -9,6 +9,7 @@ import {
   youtubeEmbed,
   escapeHtml,
   validateYoutubeUrl,
+  generateGoRedirect,
 } from './build.js'
 
 const sampleConcept = {
@@ -549,5 +550,24 @@ describe('UC-7: Build script — HTML generation', () => {
         color: '#6495ED',
       })
     })
+  })
+})
+
+describe('generateGoRedirect()', () => {
+  it('leitet auf die Konzeptseite, nicht direkt zu YouTube', () => {
+    const html = generateGoRedirect(sampleConcept)
+    expect(html).toContain('/concept/microservices')
+    expect(html).not.toContain('youtube.com')
+    expect(html).not.toContain('youtu.be')
+  })
+
+  it('funktioniert ohne JavaScript (statischer Meta-Refresh)', () => {
+    const html = generateGoRedirect(sampleConcept)
+    expect(html).toMatch(/<meta http-equiv="refresh"[^>]*\/concept\/microservices/)
+  })
+
+  it('bietet auch bei blockiertem Refresh einen sichtbaren Link an', () => {
+    const html = generateGoRedirect(sampleConcept)
+    expect(html).toMatch(/<a href="[^"]*\/concept\/microservices"/)
   })
 })


### PR DESCRIPTION
## Problem

Die `/go/{token}`-Seite, auf die die QR-Codes im eBook zeigen, sprang per JavaScript sofort zu YouTube:

```js
if(url)window.location.replace(url);
```

Daraus folgten zwei Probleme:

1. **QR-Scans wurden nicht gezählt.** Die Seite enthielt kein GoatCounter-Snippet, und der Besucher war weg, bevor überhaupt etwas hätte laden können. In der Statistik tauchten die Scans nicht auf.
2. **Das Video lief außerhalb des eigenen Kontexts** — direkt auf YouTube, ohne den zugehörigen Konzepttext.

## Lösung

`/go/{token}` führt jetzt auf `/concept/{id}`. Diese Seite existiert bereits, bettet das Video über `youtubeEmbed()` ein, zeigt den Konzepttext und trägt das GoatCounter-Snippet. Beide Probleme sind damit ohne neuen Seitentyp gelöst.

Zusätzlich: **statischer `<meta http-equiv="refresh">` statt JavaScript.** Die Weiterleitung funktioniert damit auch ohne JS, was vorher nicht der Fall war.

## Tests

`generateGoRedirect()` war bisher nicht getestet. Drei Tests ergänzt:

- leitet auf die Konzeptseite, nicht zu YouTube
- funktioniert ohne JavaScript (Meta-Refresh vorhanden)
- bietet bei blockiertem Refresh einen sichtbaren Link

Vorher 76 Tests, jetzt 79, alle grün.

## Zu prüfen

Ob GoatCounter QR-Traffic von organischem Traffic unterscheiden soll. Aktuell landen beide als normaler Aufruf von `/concept/{id}` in der Statistik. Falls die Unterscheidung gewünscht ist, wäre ein Query-Parameter (z. B. `?via=qr`) der nächste Schritt — bewusst nicht Teil dieses PRs.